### PR TITLE
Update node-hid dependency to support Node 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
      "powermate"
   ],
   "dependencies": {
-    "node-hid": "0.2.x"
+    "node-hid": "0.5.x"
   },
   "devDependencies": {
     "jshint": "latest",


### PR DESCRIPTION
Hi Sandeep,

I've been using `node-powermate` in a module of mine and recently someone tried to build it using Node 4.3.1. The installation failed because `node-hid@0.2.3` specifies a bundleDependency on the nonexistent [`hidapi` ](https://www.npmjs.com/package/hidapi) package. I assume older versions of Node like 0.8.x and 0.10.x ignored bundleDependencies, but newer Node versions like 4.3.1 and possibly 0.12.x fail with a 404:

```
$ npm install
 
> node-hid@0.2.3 preinstall /home/user/mymodule/node_modules/node-powermate/node_modules/node-hid
> sh get-hidapi.sh
Cloning into 'hidapi'...
remote: Counting objects: 1965, done.
remote: Total 1965 (delta 0), reused 0 (delta 0), pack-reused 1965
Receiving objects: 100% (1965/1965), 2.80 MiB | 802 KiB/s, done.
Resolving deltas: 100% (1087/1087), done.
npm ERR! Linux 3.2.0-29-generic
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install"
npm ERR! node v4.3.1
npm ERR! npm  v2.14.12
npm ERR! code E404
npm ERR! 404 Registry returned 404 for GET on https://registry.npmjs.org/hidapi
npm ERR! 404 
npm ERR! 404 'hidapi' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 It was specified as a dependency of 'node-hid'
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```

This issue has been fixed in [`node-hid@0.4.0`](https://github.com/node-hid/node-hid/commit/bd2a7fbaa39515cb964c77203f882fe8fc2dc0ca#diff-b9cfc7f2cdf78a7f4b91a753d10865a2).

This pull request updates the version of `node-hid` that `node-powermate` depends on from 0.2.x to 0.5.x. I have tested this by successfully building on a Linux machine with Node 4.3.1 and a Raspberry Pi with Node 0.10.17. I verified that the new version of `node-hid` works with the Powermate connected to the Raspberry Pi.