### PR TITLE
added disconnected event for when a powermate is unplugged

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Wheel turn:
 powermate.on('wheelTurn', callback(wheelDelta));
 ```
 
+Disconnected:
+
+```javascript
+powermate.on('disconnected', callback());
+```
+
 ### Brightness
 
 Brightness range is: 0 - 255

--- a/powermate.js
+++ b/powermate.js
@@ -185,7 +185,11 @@ PowerMate.prototype._parseRead = function(error, data) {
   if (this._closed) {
     return;
   } else if (error) {
-    throw error;
+    if (error.message == "could not read from HID device") {
+      process.nextTick(() => { this.close(); });
+      this.emit('disconnected');
+    } else
+      throw error;
   } else if (data) {
     var buttonState = data[0];
     if (buttonState !== this._buttonState) {


### PR DESCRIPTION
Sandeep,

I've added a disconnect method to your powermate library ... I had to do the nextTick() or we had a segfault in HID's native code... The native readAsync() was still processing stuff so you can't .close() to free it up from the read callback.