### PR TITLE
node-hid dependency update 0.5.x => 0.7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
      "powermate"
   ],
   "dependencies": {
-    "node-hid": "0.5.x"
+    "node-hid": "0.7.x"
   },
   "devDependencies": {
     "jshint": "latest",


### PR DESCRIPTION
Current [`node-hid`](https://github.com/node-hid/node-hid) dependency version (0.5.x) throws the following errors on Node 10 / OSX during pre-install:

```
 LIBTOOL-STATIC Release/hidapi.a
  CXX(target) Release/obj.target/HID/src/HID.o
../src/HID.cc:207:45: error: no matching member function for call to 'NewInstance'
    Local<Object> buf = nodeBufConstructor->NewInstance(1, nodeBufferArgs);
                        ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
```

Updated to latest version fixes this.