### PR TITLE
support for different HID driver type

### DIFF
--- a/powermate.js
+++ b/powermate.js
@@ -15,6 +15,13 @@ var SET_PULSE_AWAKE = 0x03;
 var SET_PULSE_MODE = 0x04;
 
 function PowerMate(index) {
+  if (typeof(index) == "object") {
+    if (index['hidDriver']) {
+      HID.setDriverType(index['hidDriver']);
+    }
+    index = index['index'];
+  }
+
   var powerMateHIDdevices = HID.devices(VENDOR_ID, PRODUCT_ID);
 
   if (powerMateHIDdevices.length === 0) {


### PR DESCRIPTION
new node-hid supports libusb based HID driver -- this commit allows you to pass in { hidDriver: 'libusb' } into the constructor

it also allows for { index: 2 }